### PR TITLE
Order theme_park & rides indexes

### DIFF
--- a/app/controllers/rides_controller.rb
+++ b/app/controllers/rides_controller.rb
@@ -1,6 +1,6 @@
 class RidesController < ApplicationController
   def index
-    @rides = Ride.all
+    @rides = Ride.order(created_at: :desc)
   end
 
   def show

--- a/app/controllers/theme_parks_controller.rb
+++ b/app/controllers/theme_parks_controller.rb
@@ -1,6 +1,6 @@
 class ThemeParksController < ApplicationController
   def index
-    @theme_parks = ThemePark.all
+    @theme_parks = ThemePark.order(created_at: :desc)
   end
 
   def show

--- a/app/views/rides/index.html.erb
+++ b/app/views/rides/index.html.erb
@@ -9,5 +9,9 @@
     <% else %>
       Not Operational
     <% end %></li>
+    <li><%= ride.created_at
+                .in_time_zone("America/Denver")
+                .strftime("Created on %m/%d/%Y at %I:%M%p %Z") %>
+    </li>
   <% end %>
 </ul>

--- a/app/views/theme_parks/index.html.erb
+++ b/app/views/theme_parks/index.html.erb
@@ -2,7 +2,11 @@
 
 <ul>
   <% @theme_parks.each do |theme_park| %>
-      <li><%= theme_park.name %></li>
+      <h3><%= theme_park.name %></h3>
+      <li><%= theme_park.created_at
+                        .in_time_zone("America/Denver")
+                        .strftime("Created on %m/%d/%Y at %I:%M%p %Z") %>
+      </li>
     <% end %>
 </ul>
 <a href="/themeparks/new">New Theme Park</a>

--- a/spec/features/rides/index_spec.rb
+++ b/spec/features/rides/index_spec.rb
@@ -11,17 +11,20 @@ RSpec.describe 'Rides Index', type: :feature do
     ride_3 = magic_kingdom.rides.create!(name: "Space Mountain", max_occupants: 65, operational: true)
 
     visit '/rides'
-
     expect(page).to have_content(ride_1.name)
     expect(page).to have_content(ride_1.max_occupants)
     expect(page).to have_content("Operational")
+    expect(page).to have_content(ride_1.created_at.in_time_zone("America/Denver").strftime("Created on %m/%d/%Y at %I:%M%p %Z"))
+
 
     expect(page).to have_content(ride_2.name)
     expect(page).to have_content(ride_2.max_occupants)
     expect(page).to have_content("Not Operational")
+    expect(page).to have_content(ride_2.created_at.in_time_zone("America/Denver").strftime("Created on %m/%d/%Y at %I:%M%p %Z"))
 
     expect(page).to have_content(ride_3.name)
     expect(page).to have_content(ride_3.max_occupants)
     expect(page).to have_content("Operational")
+    expect(page).to have_content(ride_3.created_at.in_time_zone("America/Denver").strftime("Created on %m/%d/%Y at %I:%M%p %Z"))
   end
 end

--- a/spec/features/theme_parks/index_spec.rb
+++ b/spec/features/theme_parks/index_spec.rb
@@ -8,7 +8,10 @@ RSpec.describe 'ThemeParks Index Page', type: :feature do
     visit '/themeparks'
 
     expect(page).to have_content(tp_1.name)
+    expect(page).to have_content(tp_1.created_at.in_time_zone("America/Denver").strftime("Created on %m/%d/%Y at %I:%M%p %Z"))
+
     expect(page).to have_content(tp_2.name)
+    expect(page).to have_content(tp_2.created_at.in_time_zone("America/Denver").strftime("Created on %m/%d/%Y at %I:%M%p %Z"))
     expect(page).to have_link("New Theme Park", href: '/themeparks/new')
   end
 end


### PR DESCRIPTION
- add tests for indexes to include created_at attribute formatted
- update controllers' `index` actions to order records by `created_at: :desc`
- update views to include formatted created_at attribute